### PR TITLE
Fix invalid tool names in MCP server

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,18 @@
+# Plan to fix MCP server tool name issue
+
+The `mcp` server is rejecting tool names that contain dots. This is because the server expects tool names to match the pattern `^[a-zA-Z0-9_-]+$`. Several tools in this project use dots in their names, causing `400 Bad Request` errors.
+
+The solution is to rename the affected tools by replacing the dots with underscores. This will make the tool names compliant with the `mcp` server's requirements.
+
+Here are the files that need to be modified and the changes to be made:
+
+1.  **`src/mcp_pytools/tools/index_build.py`**:
+    -   Change the `name` property of the `IndexBuildTool` class from `"index.build"` to `"index_build"`.
+
+2.  **`src/mcp_pytools/tools/index_invalidate.py`**:
+    -   Change the `name` property of the `IndexInvalidateTool` class from `"index.invalidate"` to `"index_invalidate"`.
+
+3.  **`src/mcp_pytools/tools/index_status.py`**:
+    -   Change the `name` property of the `IndexStatusTool` class from `"index.status"` to `"index_status"`.
+
+These changes will resolve the `Invalid 'tools[*].name'` errors and allow the `mcp` server to work correctly.

--- a/src/mcp_pytools/tools/index_build.py
+++ b/src/mcp_pytools/tools/index_build.py
@@ -8,7 +8,7 @@ class IndexBuildTool(Tool):
 
     @property
     def name(self) -> str:
-        return "index.build"
+        return "index_build"
 
     @property
     def description(self) -> str:

--- a/src/mcp_pytools/tools/index_invalidate.py
+++ b/src/mcp_pytools/tools/index_invalidate.py
@@ -8,7 +8,7 @@ class IndexInvalidateTool(Tool):
 
     @property
     def name(self) -> str:
-        return "index.invalidate"
+        return "index_invalidate"
 
     @property
     def description(self) -> str:

--- a/src/mcp_pytools/tools/index_status.py
+++ b/src/mcp_pytools/tools/index_status.py
@@ -8,7 +8,7 @@ class IndexStatusTool(Tool):
 
     @property
     def name(self) -> str:
-        return "index.status"
+        return "index_status"
 
     @property
     def description(self) -> str:


### PR DESCRIPTION
The MCP server was rejecting tool names that contained dots, as they did not match the required pattern '^[a-zA-Z0-9_-]+$'. This was causing '400 Bad Request' errors.

This commit fixes the issue by replacing the dots with underscores in the affected tool names:
- `index.build` -> `index_build`
- `index.invalidate` -> `index_invalidate`
- `index.status` -> `index_status`

A failing test in `tests/test_organize_imports.py` was also investigated. The failure seems to be unrelated to these changes. The test was restored to its original state.