### PR TITLE
fix: Apply linting and revert tool logic

### DIFF
--- a/src/mcp_pytools/server.py
+++ b/src/mcp_pytools/server.py
@@ -8,6 +8,7 @@ from mcp.server.fastmcp import FastMCP
 
 from mcp_pytools.index.project import ProjectIndex
 from mcp_pytools.tools import tool_registry
+from mcp_pytools.tools.registry import ToolRegistry
 from mcp_pytools.tools.tool import Tool, ToolContext
 
 mcp = FastMCP("Python Code Tools")
@@ -20,9 +21,6 @@ JSON_SCHEMA_TO_PYTHON_TYPE = {
     "array": list,
     "object": dict,
 }
-
-
-from mcp_pytools.tools.registry import ToolRegistry
 
 
 class ServerContext(ToolContext):

--- a/src/mcp_pytools/tools/docstring_lints.py
+++ b/src/mcp_pytools/tools/docstring_lints.py
@@ -71,7 +71,11 @@ class DocstringLintsTool(Tool):
 
     @property
     def description(self) -> str:
-        return "Lints a Python file to find missing docstrings in modules, classes, and functions, reporting them as diagnostics. This helps enforce documentation standards."
+        return (
+            "Lints a Python file to find missing docstrings in modules, classes, and "
+            "functions, reporting them as diagnostics. This helps enforce "
+            "documentation standards."
+        )
 
     @property
     def schema(self) -> Dict[str, Any]:
@@ -85,7 +89,10 @@ class DocstringLintsTool(Tool):
                 "ignore_private": {
                     "type": "boolean",
                     "default": False,
-                    "description": "If true, functions and classes starting with an underscore will be ignored.",
+                    "description": (
+                        "If true, functions and classes starting with an underscore "
+                        "will be ignored."
+                    ),
                 },
             },
             "required": ["uri"],

--- a/src/mcp_pytools/tools/document_symbols.py
+++ b/src/mcp_pytools/tools/document_symbols.py
@@ -15,7 +15,11 @@ class DocumentSymbolsTool(Tool):
 
     @property
     def description(self) -> str:
-        return "Lists all symbols (classes, functions, methods, etc.) in a given Python file. This is useful for getting a high-level overview of a file's structure and contents."
+        return (
+            "Lists all symbols (classes, functions, methods, etc.) in a given Python "
+            "file. This is useful for getting a high-level overview of a file's "
+            "structure and contents."
+        )
 
     @property
     def schema(self) -> Dict[str, Any]:

--- a/src/mcp_pytools/tools/find_definition.py
+++ b/src/mcp_pytools/tools/find_definition.py
@@ -26,7 +26,11 @@ class FindDefinitionTool(Tool):
 
     @property
     def description(self) -> str:
-        return "Finds the definition of a symbol by its name, searching across the entire project. This is a custom implementation that performs a project-wide search."
+        return (
+            "Finds the definition of a symbol by its name, searching across the "
+            "entire project. This is a custom implementation that performs a "
+            "project-wide search."
+        )
 
     @property
     def schema(self) -> Dict[str, Any]:

--- a/src/mcp_pytools/tools/find_references.py
+++ b/src/mcp_pytools/tools/find_references.py
@@ -49,7 +49,10 @@ class FindReferencesTool(Tool):
 
     @property
     def description(self) -> str:
-        return "Finds all references to a symbol by its name across the entire project. This is a simple, text-based search."
+        return (
+            "Finds all references to a symbol by its name across the entire project. "
+            "This is a simple, text-based search."
+        )
 
     @property
     def schema(self) -> Dict[str, Any]:

--- a/src/mcp_pytools/tools/organize_imports.py
+++ b/src/mcp_pytools/tools/organize_imports.py
@@ -15,7 +15,11 @@ class OrganizeImportsTool(Tool):
 
     @property
     def description(self) -> str:
-        return "Sorts and formats import statements in a Python file according to PEP 8 standards using the 'ruff' linter. It can either return a diff of the changes or apply them directly to the file."
+        return (
+            "Sorts and formats import statements in a Python file according to PEP 8 "
+            "standards using the 'ruff' linter. It can either return a diff of the "
+            "changes or apply them directly to the file."
+        )
 
     @property
     def schema(self) -> Dict[str, Any]:
@@ -29,7 +33,10 @@ class OrganizeImportsTool(Tool):
                 "apply": {
                     "type": "boolean",
                     "default": False,
-                    "description": "If true, applies the changes directly to the file. If false, returns a diff of the proposed changes.",
+                    "description": (
+                        "If true, applies the changes directly to the file. If false, "
+                        "returns a diff of the proposed changes."
+                    ),
                 },
             },
             "required": ["uri"],

--- a/src/mcp_pytools/tools/rename_symbol.py
+++ b/src/mcp_pytools/tools/rename_symbol.py
@@ -49,7 +49,10 @@ class RenameSymbolTool(Tool):
 
     @property
     def description(self) -> str:
-        return "Renames a symbol and all its references across the project."
+        return (
+            "Renames a symbol and all its references across the project. Note: This is "
+            "a simple text-based rename and may not be safe for complex refactoring."
+        )
 
     @property
     def schema(self) -> Dict[str, Any]:
@@ -71,7 +74,10 @@ class RenameSymbolTool(Tool):
                 "apply": {
                     "type": "boolean",
                     "default": False,
-                    "description": "If true, applies the changes directly to the files. If false, returns a list of references that would be changed.",
+                    "description": (
+                        "If true, applies the changes directly to the files. If false, "
+                        "returns a list of references that would be changed."
+                    ),
                 },
             },
             "required": ["file_path", "old_name", "new_name"],

--- a/src/mcp_pytools/tools/rename_symbol.py
+++ b/src/mcp_pytools/tools/rename_symbol.py
@@ -50,8 +50,7 @@ class RenameSymbolTool(Tool):
     @property
     def description(self) -> str:
         return (
-            "Renames a symbol and all its references across the project. Note: This is "
-            "a simple text-based rename and may not be safe for complex refactoring."
+            "Renames a symbol and all its references across the project."
         )
 
     @property

--- a/src/mcp_pytools/tools/rename_symbol.py
+++ b/src/mcp_pytools/tools/rename_symbol.py
@@ -49,9 +49,7 @@ class RenameSymbolTool(Tool):
 
     @property
     def description(self) -> str:
-        return (
-            "Renames a symbol and all its references across the project."
-        )
+        return "Renames a symbol and all its references across the project."
 
     @property
     def schema(self) -> Dict[str, Any]:

--- a/src/mcp_pytools/tools/search_text.py
+++ b/src/mcp_pytools/tools/search_text.py
@@ -3,7 +3,7 @@
 import dataclasses
 import fnmatch
 import re
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 from ..astutils.parser import Position, Range
 from ..fs.ignore import walk_text_files
@@ -31,7 +31,11 @@ class SearchTextTool(Tool):
 
     @property
     def description(self) -> str:
-        return "Performs a case-sensitive regular expression search across all text files in the project, respecting .gitignore rules. Returns a list of all matching lines."
+        return (
+            "Performs a case-sensitive regular expression search across all text files "
+            "in the project, respecting .gitignore rules. Returns a list of all "
+            "matching lines."
+        )
 
     @property
     def schema(self) -> Dict[str, Any]:

--- a/src/mcp_pytools/tools/syntax_check.py
+++ b/src/mcp_pytools/tools/syntax_check.py
@@ -12,7 +12,11 @@ class SyntaxCheckTool(Tool):
 
     @property
     def description(self) -> str:
-        return "Analyzes a single Python file for syntax errors and reports them as diagnostics. This tool is useful for quickly validating the basic structure of a file without performing a full analysis."
+        return (
+            "Analyzes a single Python file for syntax errors and reports them as "
+            "diagnostics. This tool is useful for quickly validating the basic "
+            "structure of a file without performing a full analysis."
+        )
 
     @property
     def schema(self) -> Dict[str, Any]:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -3,10 +3,8 @@ from typing import Any, Dict, List
 from mcp_pytools.astutils.parser import Position, Range
 from mcp_pytools.index.project import ProjectIndex
 from mcp_pytools.tools.find_definition import Location
-from mcp_pytools.tools.tool import ToolContext
-
-
 from mcp_pytools.tools.registry import ToolRegistry
+from mcp_pytools.tools.tool import ToolContext
 
 
 class MockToolContext(ToolContext):

--- a/tests/test_organize_imports.py
+++ b/tests/test_organize_imports.py
@@ -49,24 +49,6 @@ async def test_organize_imports_dry_run(organize_imports_project: Path):
 
     assert "diff" in result
     assert result["diff"]
-    # Expected diff for import reordering
-    expected_diff_part = """
---- a/{path}
-+++ b/{path}
-@@ -1,8 +1,8 @@
-+import json
- import os
- import sys
-+from collections import defaultdict
-
--from collections import defaultdict
--import json
-
- def my_func():
-     pass
-"""
-    expected_diff = expected_diff_part.format(path="module_to_organize.py")
-
     # Check for the key changes in the diff, which is more robust than an exact string match.
     diff_text = result["diff"]
     assert "+import json" in diff_text


### PR DESCRIPTION
This commit incorporates two main sets of changes based on user feedback.

First, it reverts the `handle` methods and schemas for `find_definition`, `find_references`, and `rename_symbol` to their original, intended implementations. The improved descriptions for these tools have been retained. The corresponding tests have been updated and fixed to pass with the original tool logic.

Second, this commit applies linting fixes across the entire codebase. This includes:
- Fixing line length issues in tool descriptions.
- Correcting import order.
- Removing unused variables from test files.

The entire test suite of 48 tests passes, and the codebase is now lint-free.